### PR TITLE
Added an example of Audio tag

### DIFF
--- a/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
+++ b/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
@@ -93,7 +93,7 @@
         
         <p>
             Audio courtesy: <strong>"Dancing in the Street" (Motown), Vandellas</strong>
-            <br />Source: <a href="http://www.stephaniequinn.com/samples.htm">Quinn Music</a>
+            <br />Source: <a href="http://www.stephaniequinn.com/samples.htm" target="_blank">Quinn Music</a>
         </p>
     </section>
     <section>

--- a/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
+++ b/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
@@ -85,6 +85,18 @@
         </ul>
     </section>
     <section>
+        <h2>Audio</h2>
+        <audio width="400" controls >
+            <source src="http://www.stephaniequinn.com/Music/Commercial%20DEMO%20-%2011.mp3" type="audio/mp3">
+            Your browser dose not support HTML5 audio.
+        </audio>
+        
+        <p>
+            Audio courtesy: <strong>"Dancing in the Street" (Motown), Vandellas</strong>
+            <br />Source: <a href="http://www.stephaniequinn.com/samples.htm">Quinn Music</a>
+        </p>
+    </section>
+    <section>
         <h2>Video</h2>
         <video width="400" controls>
             <source src="http://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">

--- a/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
+++ b/Topics/05. Semantic-HTML/demos/semantic-html5-tags.html
@@ -87,13 +87,13 @@
     <section>
         <h2>Audio</h2>
         <audio width="400" controls >
-            <source src="http://www.stephaniequinn.com/Music/Commercial%20DEMO%20-%2011.mp3" type="audio/mp3">
+            <source src="https://exit.sc/?url=http%3A%2F%2Falonetone.com%2Ftrgbanks%2Ftracks%2Finto-the-sunset-no-copyright-1.mp3" type="audio/mp3">
             Your browser dose not support HTML5 audio.
         </audio>
         
         <p>
-            Audio courtesy: <strong>"Dancing in the Street" (Motown), Vandellas</strong>
-            <br />Source: <a href="http://www.stephaniequinn.com/samples.htm" target="_blank">Quinn Music</a>
+            Audio courtesy: <strong>TRG Banks, Into The Sunset (No Copyright)</strong>
+            <br />Source: <a href="https://soundcloud.com/trgbanks/into-the-sunset-no-copyright" target="_blank">TRG Banks (Soundcloud)</a>
         </p>
     </section>
     <section>


### PR DESCRIPTION
Added an example of **Audio** tag in: **Topics/05. Semantic-HTML/demos/semantic-html5-tags.html**

> **Code:**

```html
<section>
    <h2>Audio</h2>
    <audio width="400" controls >
        <source src="http://www.stephaniequinn.com/Music/Commercial%20DEMO%20-%2011.mp3" type="audio/mp3">
        Your browser dose not support HTML5 audio.
    </audio>
    
    <p>
        Audio courtesy: <strong>"Dancing in the Street" (Motown), Vandellas</strong>
        <br />Source: <a href="http://www.stephaniequinn.com/samples.htm" target="_blank">Quinn Music</a>
    </p>
</section>
```

> **Snapshot:**

![1](https://cloud.githubusercontent.com/assets/14276147/15173288/e34622dc-1778-11e6-9db9-4578e8f6b079.JPG)

