### PR TITLE
Fixed broken links

### DIFF
--- a/Topics/03. HTML-Tables/demos/1. Simple-tables.html
+++ b/Topics/03. HTML-Tables/demos/1. Simple-tables.html
@@ -11,7 +11,7 @@
 			<img src="images/ppt.gif" alt="ppt" />
 		</td>
 		<td>
-			<a href="images/lecture1.ppt" title="lecture 1">Lecture 1</a>
+			<a href="https://rawgit.com/TelerikAcademy/HTML/master/Topics/01. Web-Basics/slides/index.html" target="_blank" title="lecture 1">Lecture 1</a>
 		</td>
 	  </tr>
 	  
@@ -20,7 +20,7 @@
 			<img src="images/ppt.gif" alt="ppt" />
 		</td>
 		<td>
-			<a href="images/lecture2.ppt" title="lecture 2">Lecture 2</a>
+			<a href="https://rawgit.com/TelerikAcademy/HTML/master/Topics/02. HTML-Fundamentals/slides/index.html" target="_blank" title="lecture 2">Lecture 2</a>
 		</td>
 	  </tr>
 	  
@@ -29,7 +29,7 @@
 			<img src="images/zip.gif" alt="zip" />
 		</td>
 		<td>
-			<a href="images/lecture2-demos.zip" title="lecture 2 demos">Lecture 2 - Demos</a>
+			<a href="https://github.com/TelerikAcademy/HTML/blob/master/Topics/02.%20HTML-Fundamentals/demos" target="_blank" title="lecture 2 demos">Lecture 2 - Demos</a>
 		</td>
 	  </tr>
 	</table>


### PR DESCRIPTION
There are **3 broken links** in **Topics/03. HTML-Tables/demos/1. Simple-tables.html** which just navigates to **error page**. 
I **replaced** those **broken** links **with working** ones as follows:

#### 1:

>**Before:**

```html
<a href="images/lecture1.ppt" title="lecture 1">Lecture 1</a>
```

>**After:**

````html
<a href="https://rawgit.com/TelerikAcademy/HTML/master/Topics/01. Web-Basics/slides/index.html" target="_blank" title="lecture 1">Lecture 1</a>
```

#### 2:

>**Before:**

```html
<a href="images/lecture2.ppt" title="lecture 2">Lecture 2</a>
```

>**After:**

```html
<a href="https://rawgit.com/TelerikAcademy/HTML/master/Topics/02. HTML-Fundamentals/slides/index.html" target="_blank" title="lecture 2">Lecture 2</a>
```

#### 3:

>**Before:**

```html
<a href="images/lecture2-demos.zip" title="lecture 2 demos">Lecture 2 - Demos</a>
```

>**After:**

```html
<a href="https://github.com/TelerikAcademy/HTML/blob/master/Topics/02.%20HTML-Fundamentals/demos" target="_blank" title="lecture 2 demos">Lecture 2 - Demos</a>
```